### PR TITLE
Fixed typos found when reading

### DIFF
--- a/Background/Installation/README.md
+++ b/Background/Installation/README.md
@@ -60,7 +60,7 @@ namespace BackgroundWeatherStation
 To run this code on a device:
 * Choose *Remote Machine* as the target of deployment using the menu bar of Visual Studio.
 ![Changing to remote machine](ChangingToRemoteMachine.png)
-* Pick you device from the list (or enter it's IP address manually).
+* Pick you device from the list (or enter its IP address manually).
 * Run through the menu bar (or press F5).
 
 The message should be printed on the output window every 5 seconds:

--- a/Background/Sensing/README.md
+++ b/Background/Sensing/README.md
@@ -22,12 +22,12 @@ On the dialog, choose a *Visual C# Class* and name it *WeatherStation*.
 
 ## Reading pressure data
 
-The will use the pressure data provided by the MPL3315A2. Following the datasheet, we must:
+We will use the pressure data provided by the MPL3315A2. Following the datasheet, we must:
 
 * Set the control register *CTRL_REG1* to an appropriate value depending on the desired measurement mode.
 * Read and convert the pressure.
 
-Furthermore, the sensor has a *WHO_AM_I* register for device identification. It's good practice to verify it's value before trying to use the sensor.
+Furthermore, the sensor has a *WHO_AM_I* register for device identification. It's good practice to verify its value before trying to use the sensor.
 
 We'll start the *WeatherStation* with a few definitions from the datasheet and a function to initialize the sensors. It is assumed that the weather station is connected to the default I2C bus.
 
@@ -156,7 +156,7 @@ public double ReadPressure()
 
 ## Reading temperature and humidity data
 
-The HTU21D sensor is very easy to use and doesn't require special setup. Reading the registers for temperature and pressure data will trigger a measurement and return it's value. The following definitions cover the registers that we'll be using:
+The HTU21D sensor is very easy to use and doesn't require special setup. Reading the registers for temperature and pressure data will trigger a measurement and return its value. The following definitions cover the registers that we'll be using:
 
 ```cs
 private abstract class Htu21dDefinitions

--- a/Foreground/Creating/README.md
+++ b/Foreground/Creating/README.md
@@ -32,7 +32,7 @@ private void ContentNavigate(Type page)
 }
 ```
 
-* Now, it's just a matter of creating the callbacks for button presses and call `ContentNavigate` with the target page. For example, to navigate to the `SlideShow` when the button is pressed, do:
+* Now, it's just a matter of creating the callbacks for button presses that call `ContentNavigate` with the target page. For example, to navigate to the `SlideShow` when the button is pressed, do:
 
 ```cs
 private void SlideShow_Click(object sender, RoutedEventArgs e)
@@ -41,7 +41,7 @@ private void SlideShow_Click(object sender, RoutedEventArgs e)
 }
 ```
 
-* A [Hamburguer Button]() allows the user to show or collapse the panel. The code for the button click is:
+* A hamburger button allows the user to show or collapse the panel. The code for the button click is:
 
 ```cs
 private void PanelToggle_Click(object sender, RoutedEventArgs e)

--- a/Speech/VoiceCommands/README.md
+++ b/Speech/VoiceCommands/README.md
@@ -65,7 +65,7 @@ class VoiceCommand
 }
 ```
 
-To enable the LED during voice recognition, call `SetLet`:
+To enable the LED during voice recognition, call `SetLed`:
 
 ```cs
 class VoiceCommand


### PR DESCRIPTION
I only read through sections 2 and 3 (didn't have VS available so I wasn't trying the steps/code) but some obvious non-code typos popped out at me. You might want to have an editor work through the remaining sections, as well as 2 & 3 again, to up the quality. It might help to reduce the code comments since they seem to just repeat what the documentation says but in different language; then there will be less to maintain.